### PR TITLE
fix: Remove unnecessary escapeSlash method from Toolbox

### DIFF
--- a/src/Services/Toolbox.php
+++ b/src/Services/Toolbox.php
@@ -4,13 +4,11 @@ namespace Jawira\EntityDraw\Services;
 
 use ArrayAccess;
 use Jawira\EntityDraw\Uml\ComponentInterface;
-use function addcslashes;
 use function array_reduce;
 use function strval;
 
 class Toolbox
 {
-  private const SLASH = '\\';
   public const PRIVATE = '-';
   public const PROTECTED = '#';
   public const PUBLIC = '+';
@@ -26,14 +24,6 @@ class Toolbox
     };
 
     return array_reduce($components, $reducer, '');
-  }
-
-  /**
-   * Escape back-slash in class namespaces to be displayed in PlantUml diagrams.
-   */
-  public function escapeSlash(string $fqcn): string
-  {
-    return addcslashes($fqcn, self::SLASH);
   }
 
   /**

--- a/src/Uml/Entity.php
+++ b/src/Uml/Entity.php
@@ -28,7 +28,7 @@ class Entity implements ComponentInterface
 
   private function generateHeaderAndFooter(): void
   {
-    $name = $this->toolbox->escapeSlash($this->metadata->getName());
+    $name = $this->metadata->getName();
     $header = "class $name {";
     $isAbstract = $this->metadata->getReflectionClass()->isAbstract();
     if ($isAbstract) {

--- a/src/Uml/Inheritance.php
+++ b/src/Uml/Inheritance.php
@@ -3,21 +3,17 @@
 namespace Jawira\EntityDraw\Uml;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Jawira\EntityDraw\Services\Toolbox;
 
 class Inheritance implements ComponentInterface
 {
-  private Toolbox $toolbox;
-
   public function __construct(private ClassMetadata $entity, private string $subClass)
   {
-    $this->toolbox = new Toolbox();
   }
 
   public function __toString(): string
   {
-    $name = $this->toolbox->escapeSlash($this->entity->getName());
-    $subClass = $this->toolbox->escapeSlash($this->subClass);
+    $name = $this->entity->getName();
+    $subClass = $this->subClass;
 
     return "$name <|-- $subClass" . PHP_EOL;
   }

--- a/src/Uml/Relation.php
+++ b/src/Uml/Relation.php
@@ -5,7 +5,6 @@ namespace Jawira\EntityDraw\Uml;
 use ArrayAccess;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Jawira\EntityDraw\EntityDrawException;
-use Jawira\EntityDraw\Services\Toolbox;
 
 /**
  * Association between entities.
@@ -32,11 +31,8 @@ class Relation implements ComponentInterface
    */
   private const MANY_TO_MANY = 8;
 
-  private Toolbox $toolbox;
-
   public function __construct(private ClassMetadata $entity, private array|ArrayAccess $associationMapping)
   {
-    $this->toolbox = new Toolbox();
   }
 
   /**
@@ -85,12 +81,12 @@ class Relation implements ComponentInterface
 
   public function __toString(): string
   {
-    $entityName = $this->toolbox->escapeSlash($this->entity->getName());
+    $entityName = $this->entity->getName();
     $targetEntity = $this->associationMapping['targetEntity'];
     if (!is_string($targetEntity)) {
       throw new EntityDrawException('Cannot determine target entity name.');
     }
-    $targetEntity = $this->toolbox->escapeSlash($targetEntity);
+    $targetEntity = $targetEntity;
     $unidirectional = empty($this->associationMapping['inversedBy']) ? '>' : '';
 
     return sprintf(


### PR DESCRIPTION
The escapeSlash method is not required anymore since PlantUML doesn't require this anymore. Keeping this method will make fail diagram conversion.

See https://github.com/jawira/doctrine-diagram-bundle/issues/62