### PR TITLE
feat: Normalize array as default property value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 /deleteme*
+/.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^v3.75",
     "jawira/skeleton": "^v2.27",
+    "phpunit/phpunit": "^10.5",
     "vimeo/psalm": "6.7.*"
   },
   "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true">
+
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+
+  <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
+</phpunit>

--- a/src/Services/VarNormalizer.php
+++ b/src/Services/VarNormalizer.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Jawira\EntityDraw\Services;
+
+use function str_ends_with;
+use function str_starts_with;
+
+/**
+ * This method will normalize and escape special PlantUML characters to display
+ * diagrams properly.
+ */
+class VarNormalizer
+{
+  /**
+   * Converts "NULL" to "null".
+   */
+  public function lowercaseNull(string $var): string
+  {
+    if ($var === 'NULL') {
+      return 'null';
+    }
+
+    return $var;
+  }
+
+
+  /**
+   * Replaces "array ()" with "[]".
+   *
+   * Only the first array will be replaced, nested arrays are kept as-is.
+   */
+  public function shortArraySyntax(string $varExport): string
+  {
+    $isArray = str_starts_with($varExport, 'array (') && str_ends_with($varExport, ')');
+    if (!$isArray) {
+      return $varExport;
+    }
+    $varExport = substr_replace($varExport, '[', 0, 7);
+    $varExport = substr_replace($varExport, ']', -1, 1);
+
+    return $varExport;
+  }
+
+  /**
+   * Removes all new lines from the input string.
+   */
+  public function removeNewLines(string $varExport): string
+  {
+    return strtr($varExport, ["\r" => '', "\n" => '']);
+  }
+
+  /**
+   * Escape opening and closing parenthesis.
+   *
+   * Parenthesis can create problems in Class diagrams, any parenthesis will
+   * convert a property in a method.
+   */
+  public function escapeParenthesis(string $varExport): string
+  {
+    return strtr($varExport, ['(' => '<U+0028>', ')' => '<U+0029>']);
+  }
+
+}

--- a/src/Uml/Property.php
+++ b/src/Uml/Property.php
@@ -3,17 +3,21 @@
 namespace Jawira\EntityDraw\Uml;
 
 use Jawira\EntityDraw\Services\Toolbox;
+use Jawira\EntityDraw\Services\VarNormalizer;
 use function str_contains;
 use function strval;
 use function var_export;
 
 class Property implements ComponentInterface
 {
+  private VarNormalizer $varNormalizer;
+
   /**
    * @see https://stackoverflow.com/questions/41870513/how-to-show-attribute-as-readonly-in-uml
    */
   public function __construct(private readonly \ReflectionProperty $property)
   {
+    $this->varNormalizer = new VarNormalizer();
   }
 
 
@@ -35,7 +39,10 @@ class Property implements ComponentInterface
     $value = $this->property->getDefaultValue();
 
     $varExport = var_export($value, true);
-    $varExport = $varExport === 'NULL' ? 'null' : $varExport;
+    $varExport = $this->varNormalizer->lowercaseNull($varExport);
+    $varExport = $this->varNormalizer->shortArraySyntax($varExport);
+    $varExport = $this->varNormalizer->removeNewLines($varExport);
+    $varExport = $this->varNormalizer->escapeParenthesis($varExport);
 
     return ' = ' . $varExport;
   }

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Jawira\EntityDraw\Services\VarNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class NormalizerTest extends TestCase
+{
+  private VarNormalizer $varNormalizer;
+
+  protected function setUp(): void
+  {
+    $this->varNormalizer = new VarNormalizer();
+  }
+
+  /**
+   * @covers \Jawira\EntityDraw\Services\VarNormalizer::escapeParenthesis
+   * @dataProvider escapeParenthesisProvider
+   */
+  public function testEscapeParenthesis($value, $expected): void
+  {
+    $actual = $this->varNormalizer->escapeParenthesis($value);
+    $this->assertEquals($expected, $actual);
+  }
+
+  public static function escapeParenthesisProvider(): array
+  {
+    return [
+      ['()', '<U+0028><U+0029>'],
+      ['(dev)', '<U+0028>dev<U+0029>'],
+      ['(((', '<U+0028><U+0028><U+0028>'],
+      ["array (\n)", "array <U+0028>\n<U+0029>"],
+    ];
+  }
+
+  /**
+   * @covers       \Jawira\EntityDraw\Services\VarNormalizer::removeNewLines
+   * @dataProvider removeNewLineProvider
+   */
+  public function testRemoveNewLine($value, $expected): void
+  {
+    $actual = $this->varNormalizer->removeNewLines($value);
+    $this->assertEquals($expected, $actual);
+  }
+
+  public static function removeNewLineProvider(): array
+  {
+    return [
+      ["\n", ''],
+      ["\n\n\n\n", ''],
+      ["\r\n\r\n", ''],
+      ["Foo\r\nBar\r\nBaz\r\n", 'FooBarBaz'],
+    ];
+  }
+
+  /**
+   * @covers       \Jawira\EntityDraw\Services\VarNormalizer::shortArraySyntax
+   * @dataProvider shortArraySyntaxProvider
+   */
+  public function testShortArraySyntax($value, $expected): void
+  {
+
+    $actual = $this->varNormalizer->shortArraySyntax($value);
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  public static function shortArraySyntaxProvider(): array
+  {
+    return [
+      ["array ()", "[]"],
+      ["array (\n\n\n)", "[\n\n\n]"],
+      ["array (xxxxxxxxxxx)", "[xxxxxxxxxxx]"],
+      ["array (array ())", "[array ()]"],
+    ];
+  }
+
+  /**
+   * @covers       \Jawira\EntityDraw\Services\VarNormalizer::lowercaseNull
+   * @dataProvider lowercaseNullProvider
+   */
+  public function testLowercaseNull($value, $expected): void
+  {
+    $actual = $this->varNormalizer->lowercaseNull($value);
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  public static function lowercaseNullProvider(): array
+  {
+    return [
+      ['NULL', 'null'],
+      ['NULL ', 'NULL '],
+      ['NuLl', 'NuLl'],
+      ['null', 'null'],
+      ['nulL', 'nulL'],
+      ['Kano', 'Kano'],
+    ];
+  }
+}


### PR DESCRIPTION
Normalization is required since PlantUML will interpret parenthesis as a method.

See https://github.com/jawira/doctrine-diagram-bundle/issues/64